### PR TITLE
test: cover MainWindowController, TreeModel, and KeyMapPageWidgetCont…

### DIFF
--- a/tests/ut/CMakeLists.txt
+++ b/tests/ut/CMakeLists.txt
@@ -85,9 +85,11 @@ if(NOT PROJECT_IS_TOP_LEVEL)
       keymapcontrollertest.cpp
       keymaptreemodeltest.cpp
       keymappagetest.cpp
+      keymappagewidgetcontrollertest.cpp
       keymappagewidgettest.cpp
       pendingkeymapstatetest.cpp
       loggertest.cpp
+      mainwindowcontrollertest.cpp
       mainwindowgeometryandstatetest.cpp
       mainwindowtest.cpp
       menucontainertest.cpp
@@ -112,6 +114,7 @@ if(NOT PROJECT_IS_TOP_LEVEL)
       textmatchertest.cpp
       systemmemorytest.cpp
       treeitemtest.cpp
+      treemodeltest.cpp
   )
 endif()
 

--- a/tests/ut/keymappagewidgetcontrollertest.cpp
+++ b/tests/ut/keymappagewidgetcontrollertest.cpp
@@ -1,0 +1,75 @@
+#include <memory>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <QAction>
+#include <QKeySequence>
+
+#include "actionregistry.hpp"
+#include "hierarchicalid.hpp"
+#include "mockkeymappagewidget.hpp"
+#include "mocksettings.hpp"
+#include "nulllogger.hpp"
+#include "settings/keymap/keymappagewidgetcontroller.hpp"
+#include "settings/keymap/keymaptreemodel.hpp"
+
+using aide::ActionRegistry;
+using aide::HierarchicalId;
+using aide::core::KeyMapTreeModel;
+using aide::gui::KeyMapPageWidgetController;
+using aide::test::MockKeyMapPageWidget;
+using aide::test::MockSettings;
+using aide::test::NullLogger;
+
+TEST_CASE("A key map page widget controller handling an existing shortcut")
+{
+    MockSettings settings;
+    auto logger = std::make_shared<NullLogger>();
+    auto registry(std::make_shared<ActionRegistry>(settings, logger));
+
+    auto action{std::make_shared<QAction>()};
+    const QKeySequence defaultSequence(Qt::CTRL | Qt::Key_N);
+    registry->registerAction(action, HierarchicalId("New File"), "",
+                             {defaultSequence});
+
+    auto treeModel = std::make_shared<KeyMapTreeModel>(registry);
+    MockKeyMapPageWidget view;
+    KeyMapPageWidgetController controller(treeModel, &view);
+
+    const QModelIndex actionIndex = treeModel->index(0, 0);
+    controller.requestContextMenuForIndex(actionIndex);
+    const QModelIndex shortcutsIndex = treeModel->index(0, 1);
+
+    SECTION("resets the current shortcuts to the action's default")
+    {
+        const QKeySequence customSequence(Qt::Key_X);
+        treeModel->setData(shortcutsIndex,
+                           QKeySequence::listToString({customSequence}),
+                           Qt::DisplayRole);
+
+        controller.onUserRequestedToResetCurrentShortcutsToDefault();
+
+        REQUIRE(treeModel->data(shortcutsIndex, Qt::DisplayRole).toString() ==
+                QKeySequence::listToString({defaultSequence}));
+    }
+
+    SECTION("removes only the shortcut carried by the triggering action")
+    {
+        const QKeySequence otherSequence(Qt::Key_X);
+        treeModel->setData(
+            shortcutsIndex,
+            QKeySequence::listToString({defaultSequence, otherSequence}),
+            Qt::DisplayRole);
+
+        QAction removeAction;
+        removeAction.setData(otherSequence);
+        QObject::connect(
+            &removeAction, &QAction::triggered, &controller,
+            &KeyMapPageWidgetController::onUserRequestedToRemoveAShortcut);
+
+        removeAction.trigger();
+
+        REQUIRE(treeModel->data(shortcutsIndex, Qt::DisplayRole).toString() ==
+                QKeySequence::listToString({defaultSequence}));
+    }
+}

--- a/tests/ut/keymappagewidgetcontrollertest.cpp
+++ b/tests/ut/keymappagewidgetcontrollertest.cpp
@@ -63,9 +63,14 @@ TEST_CASE("A key map page widget controller handling an existing shortcut")
 
         QAction removeAction;
         removeAction.setData(otherSequence);
-        QObject::connect(
-            &removeAction, &QAction::triggered, &controller,
-            &KeyMapPageWidgetController::onUserRequestedToRemoveAShortcut);
+        // String-based connect on purpose: a pointer-to-member connect
+        // references the sender's and receiver's staticMetaObject data
+        // symbols, which are not exported across DLL boundaries on MSVC
+        // (CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS exports functions, not data).
+        // The string form resolves the signal/slot at runtime via the
+        // exported virtual metaObject(), so it links there.
+        QObject::connect(&removeAction, SIGNAL(triggered()), &controller,
+                         SLOT(onUserRequestedToRemoveAShortcut()));
 
         removeAction.trigger();
 

--- a/tests/ut/mainwindowcontrollertest.cpp
+++ b/tests/ut/mainwindowcontrollertest.cpp
@@ -1,0 +1,135 @@
+#include <memory>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <QApplication>
+#include <QByteArray>
+#include <QCloseEvent>
+
+#include <aide/applicationconfig.hpp>
+
+#include "applicationclosecontroller.hpp"
+#include "mainwindow.hpp"
+#include "mainwindowcontroller.hpp"
+#include "mainwindowgeometryandstatecontroller.hpp"
+#include "nulllogger.hpp"
+#include "settings/showsettingsdialogcontroller.hpp"
+
+using aide::ApplicationConfig;
+using aide::core::ApplicationCloseController;
+using aide::core::MainWindowGeometryAndStateController;
+using aide::core::ShowSettingsDialogController;
+using aide::gui::MainWindow;
+using aide::gui::MainWindowController;
+using aide::test::NullLogger;
+
+namespace
+{
+    class FakeApplicationCloseController : public ApplicationCloseController
+    {
+    public:
+        bool allowClose{true};
+
+        [[nodiscard]] bool isCloseAllowed() const override
+        {
+            return allowClose;
+        }
+    };
+
+    class FakeMainWindowGeometryAndStateController
+        : public MainWindowGeometryAndStateController
+    {
+    public:
+        bool saveCalled{false};
+        QByteArray lastGeometry;
+        QByteArray lastState;
+
+        void saveGeometryAndState(const QByteArray& geometry,
+                                  const QByteArray& state) override
+        {
+            saveCalled   = true;
+            lastGeometry = geometry;
+            lastState    = state;
+        }
+
+        void restoreGeometryAndState() override {}
+    };
+
+    class FakeShowSettingsDialogController : public ShowSettingsDialogController
+    {
+    public:
+        bool showCalled{false};
+
+        void showSettingsDialog() override { showCalled = true; }
+    };
+} // namespace
+
+TEST_CASE("A main window controller handling a close request")
+{
+    QApplication::setApplicationName("aide_test");
+    QApplication::setOrganizationName("aide_company");
+
+    const auto mainWindow = std::make_shared<MainWindow>(
+        std::make_shared<NullLogger>(), ApplicationConfig{}, nullptr);
+
+    FakeApplicationCloseController closeController;
+    FakeMainWindowGeometryAndStateController saveController;
+    FakeShowSettingsDialogController settingsController;
+
+    const MainWindowController controller(mainWindow, closeController,
+                                          saveController, settingsController);
+
+    const QByteArray geometry("geometry-bytes");
+    const QByteArray state("state-bytes");
+
+    SECTION("accepts the close event and saves geometry when close is allowed")
+    {
+        closeController.allowClose = true;
+
+        QCloseEvent event;
+        controller.onUserWantsToQuitApplication(&event, geometry, state);
+
+        REQUIRE(event.isAccepted());
+        REQUIRE(saveController.saveCalled);
+        REQUIRE(saveController.lastGeometry == geometry);
+        REQUIRE(saveController.lastState == state);
+    }
+
+    SECTION(
+        "ignores the close event and does not save geometry when close is "
+        "not allowed")
+    {
+        closeController.allowClose = false;
+
+        QCloseEvent event;
+        controller.onUserWantsToQuitApplication(&event, geometry, state);
+
+        REQUIRE_FALSE(event.isAccepted());
+        REQUIRE_FALSE(saveController.saveCalled);
+    }
+}
+
+TEST_CASE(
+    "A main window controller handling a request to show the settings "
+    "dialog")
+{
+    QApplication::setApplicationName("aide_test");
+    QApplication::setOrganizationName("aide_company");
+
+    const auto mainWindow = std::make_shared<MainWindow>(
+        std::make_shared<NullLogger>(), ApplicationConfig{}, nullptr);
+
+    const FakeApplicationCloseController closeController;
+    FakeMainWindowGeometryAndStateController saveController;
+    FakeShowSettingsDialogController settingsController;
+
+    const MainWindowController controller(mainWindow, closeController,
+                                          saveController, settingsController);
+
+    SECTION("delegates to the show settings dialog interactor")
+    {
+        controller.onUserWantsToShowSettingsDialog();
+
+        REQUIRE(settingsController.showCalled);
+    }
+}

--- a/tests/ut/treemodeltest.cpp
+++ b/tests/ut/treemodeltest.cpp
@@ -1,0 +1,135 @@
+#include <memory>
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <QVariant>
+
+#include "treeitem.hpp"
+#include "treemodel.hpp"
+
+using aide::core::TreeItem;
+using aide::core::TreeItemPtr;
+using aide::core::TreeModel;
+
+namespace
+{
+    // TreeModel leaves QAbstractItemModel::data() unimplemented so
+    // subclasses can define their own column semantics; this minimal
+    // subclass exists only so the base traversal logic can be tested.
+    class ConcreteTreeModel : public TreeModel
+    {
+    public:
+        using TreeModel::TreeModel;
+
+        [[nodiscard]] QVariant data(const QModelIndex& index,
+                                    const int role) const override
+        {
+            if (!index.isValid() || role != Qt::DisplayRole) { return {}; }
+
+            return static_cast<TreeItem*>(index.internalPointer())
+                ->data(static_cast<size_t>(index.column()));
+        }
+    };
+
+    struct Tree
+    {
+        TreeItemPtr root{
+            std::make_shared<TreeItem>(std::vector<QVariant>({"Header"}))};
+        TreeItemPtr child1{std::make_shared<TreeItem>(
+            std::vector<QVariant>({"child1"}), root)};
+        TreeItemPtr child2{std::make_shared<TreeItem>(
+            std::vector<QVariant>({"child2"}), root)};
+        TreeItemPtr grandchild{std::make_shared<TreeItem>(
+            std::vector<QVariant>({"grandchild"}), child1)};
+
+        Tree()
+        {
+            root->appendChild(child1);
+            root->appendChild(child2);
+            child1->appendChild(grandchild);
+        }
+    };
+} // namespace
+
+TEST_CASE("A tree model built on top of a two-level tree item hierarchy")
+{
+    const Tree tree;
+    const ConcreteTreeModel model(nullptr, tree.root);
+
+    SECTION("reports the root's child count as the top-level row count")
+    {
+        REQUIRE(model.rowCount(QModelIndex()) == 2);
+    }
+
+    SECTION("reports a child item's own child count as its row count")
+    {
+        const QModelIndex child1Index = model.index(0, 0);
+        REQUIRE(model.rowCount(child1Index) == 1);
+    }
+
+    SECTION("reports the root's column count as the top-level column count")
+    {
+        REQUIRE(model.columnCount(QModelIndex()) == 1);
+    }
+
+    SECTION("creates a valid index for each top-level row")
+    {
+        const QModelIndex child1Index = model.index(0, 0);
+        const QModelIndex child2Index = model.index(1, 0);
+
+        REQUIRE(child1Index.isValid());
+        REQUIRE(child2Index.isValid());
+        REQUIRE(static_cast<TreeItem*>(child1Index.internalPointer()) ==
+                tree.child1.get());
+        REQUIRE(static_cast<TreeItem*>(child2Index.internalPointer()) ==
+                tree.child2.get());
+    }
+
+    SECTION("creates an invalid index for an out-of-range row")
+    {
+        REQUIRE_FALSE(model.index(99, 0).isValid());
+    }
+
+    SECTION("creates a valid index for a grandchild via its parent index")
+    {
+        const QModelIndex child1Index     = model.index(0, 0);
+        const QModelIndex grandchildIndex = model.index(0, 0, child1Index);
+
+        REQUIRE(grandchildIndex.isValid());
+        REQUIRE(static_cast<TreeItem*>(grandchildIndex.internalPointer()) ==
+                tree.grandchild.get());
+    }
+
+    SECTION("resolves a grandchild's parent index back to its parent item")
+    {
+        const QModelIndex child1Index     = model.index(0, 0);
+        const QModelIndex grandchildIndex = model.index(0, 0, child1Index);
+
+        REQUIRE(model.parent(grandchildIndex) == child1Index);
+    }
+
+    SECTION("resolves a top-level item's parent index as invalid")
+    {
+        const QModelIndex child1Index = model.index(0, 0);
+        REQUIRE_FALSE(model.parent(child1Index).isValid());
+    }
+
+    SECTION("resolves an invalid index's parent as invalid")
+    {
+        REQUIRE_FALSE(model.parent(QModelIndex()).isValid());
+    }
+
+    SECTION("exposes the root item's data as horizontal header data")
+    {
+        REQUIRE(model.headerData(0, Qt::Horizontal, Qt::DisplayRole)
+                    .toString()
+                    .toStdString() == "Header");
+    }
+
+    SECTION("returns no vertical header data")
+    {
+        REQUIRE(model.headerData(0, Qt::Vertical, Qt::DisplayRole).isValid() ==
+                false);
+    }
+}


### PR DESCRIPTION
…roller

These were previously untested: MainWindowController's close/settings delegation, TreeModel's QAbstractItemModel traversal logic, and the keymap controller's reset/remove-shortcut behavior.