### PR TITLE
feat!: require Qt 6.5+, drop Qt5 support and add Ubuntu 26.04 to CI

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+self-hosted-runner:
+  # ubuntu-26.04 is a GitHub-hosted runner label in public preview and is not
+  # yet recognized by the actionlint version pinned in .pre-commit-config.yaml.
+  labels:
+    - ubuntu-26.04

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022, macos-latest, ubuntu-24.04]
+        os: [windows-2022, macos-latest, ubuntu-24.04, ubuntu-26.04]
         cmake: [3.26, 4.x]
         qt: [6.9.2]
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -25,12 +25,6 @@ jobs:
           - qt: 6.9.2
             qt_name: Qt6
 
-          - os: ubuntu-24.04
-            cmake: 4.x
-            cmake_name: CMake Latest
-            qt: 5.15.2
-            qt_name: Qt5
-
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**aIDE** is a C++20/Qt5+Qt6 framework library for building Qt-based desktop applications. It provides reusable components including action registry, settings management, key binding UI, and logging infrastructure. Consumers embed aIDE as a CMake dependency and compose an `Application` via `ApplicationBuilder`.
+**aIDE** is a C++20/Qt6 (minimum 6.5) framework library for building Qt-based desktop applications. It provides reusable components including action registry, settings management, key binding UI, and logging infrastructure. Consumers embed aIDE as a CMake dependency and compose an `Application` via `ApplicationBuilder`.
 
 ## Build System
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Think of it as the [IntelliJ Platform](https://www.jetbrains.com/opensource/idea
 - **Configurable Keybindings** — per-action key sequences stored in `QSettings`, editable through the built-in keybinding settings page
 - **Structured Logging** — [spdlog](https://github.com/gabime/spdlog)-based logging behind a `LoggerInterface`, so your components stay decoupled from the logging backend
 - **Translation Support** — `TranslatorInterface` integrates Qt's `QTranslator` with an easy hook for loading additional translation files
-- **Qt5 & Qt6** — supports both; Qt6 is preferred when available
+- **Qt6** — built and shipped against Qt 6.5+
 - **C++20** — modern, interface-driven design with no exceptions in public API
 
 ---
@@ -58,7 +58,7 @@ The following features are planned for future releases:
 |------------|----------------|
 | CMake      | 3.25            |
 | C++ compiler | C++20 (GCC 10+, Clang 12+, MSVC 2019 16.11+) |
-| Qt         | Qt 5.15 LTS **or** Qt 6.5+ |
+| Qt         | Qt 6.5+ |
 | Conan      | 2.x *(recommended for dependency management)* |
 
 **Platforms:** Linux, macOS, Windows.
@@ -183,7 +183,7 @@ aIDE uses CMake presets for all build configurations.
 - CMake 3.25+
 - Conan 2.x (`pip install conan`)
 - Clang or GCC (recommended for the `dev` preset)
-- Qt 5.15+ or Qt 6.5+
+- Qt 6.5+
 
 ### Quick start (developer build)
 

--- a/aide/dependencies/Qt.cmake
+++ b/aide/dependencies/Qt.cmake
@@ -1,28 +1,5 @@
-find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core)
+find_package(QT NAMES Qt6 REQUIRED COMPONENTS Core)
 
-find_package(Qt6 COMPONENTS Core Widgets QUIET)
+find_package(Qt6 6.5 REQUIRED COMPONENTS Core Widgets GLOBAL)
 
-if(TARGET Qt6::Core)
-  find_package(Qt6 COMPONENTS Core Widgets REQUIRED GLOBAL)
-
-  find_package(Qt6LinguistTools)
-else()
-  if(NOT TARGET Qt5::Core)
-    find_package(Qt5 COMPONENTS Core Widgets REQUIRED GLOBAL)
-
-    if(TARGET Qt5::Core AND NOT TARGET Qt::Core)
-      add_library(Qt::Core ALIAS Qt5::Core)
-      add_library(Qt::Widgets ALIAS Qt5::Widgets)
-      add_executable(Qt::moc ALIAS Qt5::moc)
-      add_executable(Qt::uic ALIAS Qt5::uic)
-      add_executable(Qt::rcc ALIAS Qt5::rcc)
-    endif()
-  endif()
-
-  find_package(Qt5LinguistTools)
-
-  if(TARGET Qt5::lrelease)
-    add_executable(Qt::lrelease ALIAS Qt5::lrelease)
-    add_executable(Qt::lupdate ALIAS Qt5::lupdate)
-  endif()
-endif()
+find_package(Qt6LinguistTools)

--- a/aide/doc/main.dox
+++ b/aide/doc/main.dox
@@ -1,8 +1,8 @@
 /** \mainpage aIDE
  * \section intro_sec Introduction
  *
- * aide is a modern, C++ native GUI application framework based on QT5 -
- * using C++11 and later
+ * aide is a modern, C++ native GUI application framework based on Qt6 -
+ * using C++20 and later
  *
- * Using aide it's easy to generate GUI application based on QT5
+ * Using aide it's easy to generate GUI application based on Qt6
  */

--- a/aide/packaging/AideConfig.cmake.in
+++ b/aide/packaging/AideConfig.cmake.in
@@ -22,11 +22,10 @@ set_target_properties(
 
 include(CMakeFindDependencyMacro)
 
-find_dependency(Qt@QT_VERSION_MAJOR@ COMPONENTS Core Widgets)
-
-if(TARGET Qt5::Core)
-  if(NOT TARGET Qt::Core)
-    add_library(Qt::Core ALIAS Qt5::Core)
-    add_library(Qt::Widgets ALIAS Qt5::Widgets)
-  endif()
-endif()
+find_dependency(
+  Qt@QT_VERSION_MAJOR@
+  6.5
+  COMPONENTS
+  Core
+  Widgets
+)

--- a/aide/src/core/appearancemanager.cpp
+++ b/aide/src/core/appearancemanager.cpp
@@ -5,11 +5,9 @@
 
 #include <QApplication>
 #include <QColor>
-#include <QIcon>
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
 #include <QGuiApplication>
+#include <QIcon>
 #include <QStyleHints>
-#endif
 
 #include "aide/hierarchicalid.hpp"
 #include "aide/settingsinterface.hpp"
@@ -203,9 +201,7 @@ void AppearanceManager::applyAppearance(const QString& themeName,
     if (newScheme != oldScheme) { emit colorSchemeChanged(newScheme); }
     emit appearanceChanged();
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
     updateSystemThemeConnection();
-#endif
 }
 
 // static
@@ -382,9 +378,7 @@ void AppearanceManager::restoreFromSettings()
     applyIconSettings(theme);
     QApplication::setFont(m_activeFont);
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
     updateSystemThemeConnection();
-#endif
 }
 
 void AppearanceManager::reapplySystemTheme()
@@ -399,7 +393,6 @@ void AppearanceManager::reapplySystemTheme()
     emit appearanceChanged();
 }
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
 void AppearanceManager::updateSystemThemeConnection()
 {
     auto* hints = QGuiApplication::styleHints();
@@ -417,4 +410,3 @@ void AppearanceManager::onOsColorSchemeChanged()
 {
     reapplySystemTheme();
 }
-#endif

--- a/aide/src/gui/CMakeLists.txt
+++ b/aide/src/gui/CMakeLists.txt
@@ -8,29 +8,16 @@ add_subdirectory(widgets)
 if(TARGET Qt::lrelease)
   set_directory_properties(PROPERTIES CLEAN_NO_CUSTOM TRUE)
 
-  if(Qt6Core_VERSION_MAJOR)
-    qt_create_translation(
-      QM_FILES
-      ${CMAKE_CURRENT_SOURCE_DIR}
-      ${CMAKE_CURRENT_SOURCE_DIR}/../core
-      res/translations/aide_de_DE.ts
-      res/translations/aide_en.ts
-      OPTIONS
-      -locations
-      none
-    )
-  else()
-    qt5_create_translation(
-      QM_FILES
-      ${CMAKE_CURRENT_SOURCE_DIR}
-      ${CMAKE_CURRENT_SOURCE_DIR}/../core
-      res/translations/aide_de_DE.ts
-      res/translations/aide_en.ts
-      OPTIONS
-      -locations
-      none
-    )
-  endif()
+  qt_create_translation(
+    QM_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../core
+    res/translations/aide_de_DE.ts
+    res/translations/aide_en.ts
+    OPTIONS
+    -locations
+    none
+  )
 
   configure_file(
     res/translations/translations.qrc.in

--- a/aide/src/gui/applicationtranslator.cpp
+++ b/aide/src/gui/applicationtranslator.cpp
@@ -36,14 +36,9 @@ ApplicationTranslator::ApplicationTranslator(LoggerPtr loggerInterface)
         "Current application language is {}",
         QLocale::languageToString(QLocale::system().language()).toStdString());
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     [[maybe_unused]] auto res{m_qtTranslator.load(
         "qt_" + QLocale::system().name(),
         QLibraryInfo::path(QLibraryInfo::TranslationsPath))};
-#else
-    m_qtTranslator.load("qt_" + QLocale::system().name(),
-                        QLibraryInfo::location(QLibraryInfo::TranslationsPath));
-#endif
 
     QApplication::installTranslator(&m_qtTranslator);
 

--- a/aide/src/gui/settings/changedetector.cpp
+++ b/aide/src/gui/settings/changedetector.cpp
@@ -137,16 +137,9 @@ namespace
                 spinBox, qOverload<int>(&QSpinBox::valueChanged),
                 settingsController,
                 &aide::gui::SettingsDialogController::onUserChangedAGuiElement);
-#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
             QObject::connect(
                 spinBox, &QSpinBox::textChanged, settingsController,
                 &aide::gui::SettingsDialogController::onUserChangedAGuiElement);
-#else
-            QObject::connect(
-                spinBox, qOverload<const QString&>(&QSpinBox::valueChanged),
-                settingsController,
-                &aide::gui::SettingsDialogController::onUserChangedAGuiElement);
-#endif
         }
         if (const auto* spinBox = qobject_cast<const QDoubleSpinBox*>(child);
             spinBox != nullptr) {
@@ -154,17 +147,9 @@ namespace
                 spinBox, qOverload<double>(&QDoubleSpinBox::valueChanged),
                 settingsController,
                 &aide::gui::SettingsDialogController::onUserChangedAGuiElement);
-#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
             QObject::connect(
                 spinBox, &QDoubleSpinBox::textChanged, settingsController,
                 &aide::gui::SettingsDialogController::onUserChangedAGuiElement);
-#else
-            QObject::connect(
-                spinBox,
-                qOverload<const QString&>(&QDoubleSpinBox::valueChanged),
-                settingsController,
-                &aide::gui::SettingsDialogController::onUserChangedAGuiElement);
-#endif
         }
     }
 

--- a/aide/src/gui/widgets/aidetableview.cpp
+++ b/aide/src/gui/widgets/aidetableview.cpp
@@ -40,14 +40,7 @@ void AideTableView::paintEvent(QPaintEvent* event)
 
     QPainter painter(viewport());
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 12, 0)
-    const auto placeHolderTextAlpha{128};
-    QColor textColor{palette().text().color()};
-    textColor.setAlpha(placeHolderTextAlpha);
-    painter.setPen(textColor);
-#else
     painter.setPen(palette().placeholderText().color());
-#endif
 
     QRect textRect = painter.fontMetrics().boundingRect(textToDisplay);
     textRect.moveCenter(viewport()->rect().center());

--- a/aide/src/gui/widgets/aidetreeview.cpp
+++ b/aide/src/gui/widgets/aidetreeview.cpp
@@ -39,14 +39,7 @@ void AideTreeView::paintEvent(QPaintEvent* event)
 
     QPainter painter(viewport());
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 12, 0)
-    const auto placeHolderTextAlpha{128};
-    QColor textColor{palette().text().color()};
-    textColor.setAlpha(placeHolderTextAlpha);
-    painter.setPen(textColor);
-#else
     painter.setPen(palette().placeholderText().color());
-#endif
 
     QRect textRect = painter.fontMetrics().boundingRect(placeHolderText);
     textRect.moveCenter(viewport()->rect().center());

--- a/aide/src/gui/widgets/multicolumnsortfilterproxymodel.cpp
+++ b/aide/src/gui/widgets/multicolumnsortfilterproxymodel.cpp
@@ -5,10 +5,6 @@
 #include <QCoreApplication>
 #include <QRegularExpression>
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 12, 0)
-#include <QDebug>
-#endif
-
 using aide::widgets::MultiColumnSortFilterProxyModel;
 
 void MultiColumnSortFilterProxyModel::setFilterForColumn(
@@ -89,15 +85,8 @@ QRegularExpression MultiColumnSortFilterProxyModel::getRegexForColumn(
     QRegularExpression regex(filterText);
 
     if (m_option == FilterOption::Wildcard) {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
         regex = QRegularExpression::fromWildcard(filterText,
                                                  filterCaseSensitivity());
-#elif QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
-        regex = QRegularExpression(
-            QRegularExpression::wildcardToRegularExpression(filterText));
-#else
-        qDebug() << "Wildcard matching not supported for Qt Versions < 5.12";
-#endif
     }
     if (filterCaseSensitivity() == Qt::CaseInsensitive) {
         regex.setPatternOptions(regex.patternOptions().setFlag(

--- a/aide/src/gui/widgets/searchfilterresultdelegate.cpp
+++ b/aide/src/gui/widgets/searchfilterresultdelegate.cpp
@@ -55,29 +55,13 @@ void SearchFilterResultDelegate::highlightMatches(
 
     if (expression.isValid() && !expression.pattern().isEmpty() &&
         !expression.pattern().endsWith('|')) {
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-        auto iterator = expression.globalMatch(m_currentValue);
-        while (iterator.hasNext()) {
-            auto match = iterator.next();
-#else
         for (const auto& match : expression.globalMatch(m_currentValue)) {
-#endif
-
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
             auto startPos = fontMetrics.horizontalAdvance(
                 m_currentValue.mid(0, match.capturedStart()));
             auto endPos =
                 startPos + fontMetrics.horizontalAdvance(m_currentValue.mid(
                                match.capturedStart(),
                                match.capturedEnd() - match.capturedStart()));
-#else
-            auto startPos =
-                fontMetrics.width(m_currentValue.mid(0, match.capturedStart()));
-            auto endPos =
-                startPos + fontMetrics.width(m_currentValue.mid(
-                               match.capturedStart(),
-                               match.capturedEnd() - match.capturedStart()));
-#endif
 
             const auto rectStartPos{
                 std::min(rect.left() + startPos, rect.right())};

--- a/aide/src/gui/widgets/searchfilterwidget.cpp
+++ b/aide/src/gui/widgets/searchfilterwidget.cpp
@@ -74,12 +74,6 @@ SearchFilterWidget::SearchFilterWidget(const HierarchicalId& id,
     connect(&m_showHideAction, &QAction::toggled, this,
             &SearchFilterWidget::onUserRequestsToChangeVisibility);
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 12, 0)
-    m_ui->regularExpression->setChecked(true);
-    m_ui->regularExpression->hide();
-    regexStateChanged(m_ui->regularExpression->isChecked());
-#endif
-
     // Set visibility delayed - overridden functions shall not be called
     // in constructor
     // NOLINTNEXTLINE

--- a/aide/src/gui/widgets/searchlineedit.cpp
+++ b/aide/src/gui/widgets/searchlineedit.cpp
@@ -69,11 +69,7 @@ void SearchLineEdit::triggerSearch(const QString& pattern)
 
 void SearchLineEdit::setTags(QList<QString> tags)
 {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
     m_tags = QSet(tags.begin(), tags.end());
-#else
-    m_tags = tags.toSet();
-#endif
 }
 
 void SearchLineEdit::paintEvent(QPaintEvent* event)
@@ -96,30 +92,18 @@ QList<QRect> SearchLineEdit::calculateHighlightRects()
     QList<QRect> rects;
 
     for (const auto& tag : m_tags) {
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-        int pos = 0;
-#else
         qsizetype pos = 0;
-#endif
         const auto currentText{this->text().toLower()};
         while (pos >= 0) {
             pos = currentText.indexOf(tag.toLower(), pos);
 
             if (pos >= 0) {
                 auto fontMetrics(this->fontMetrics());
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
                 const auto startPos =
                     fontMetrics.horizontalAdvance(this->text().mid(0, pos));
                 const auto endPos =
                     startPos + fontMetrics.horizontalAdvance(
                                    this->text().mid(pos, tag.length()));
-#else
-                const auto startPos =
-                    fontMetrics.width(this->text().mid(0, pos));
-                const auto endPos =
-                    startPos +
-                    fontMetrics.width(this->text().mid(pos, tag.length()));
-#endif
                 const QRect tagsRect{QPoint(this->rect().left() + 2 + startPos,
                                             this->rect().top() + 2),
                                      QPoint(this->rect().left() + 2 + endPos,

--- a/aide/src/include/aide/appearancemanager.hpp
+++ b/aide/src/include/aide/appearancemanager.hpp
@@ -59,12 +59,10 @@ namespace aide
         QString m_activeThemeName;
         QFont m_activeFont;
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
         void updateSystemThemeConnection();
 
     private slots:
         void onOsColorSchemeChanged();
-#endif
     };
 } // namespace aide
 

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -10,21 +10,8 @@ if(NOT TARGET Aide::AideApplication)
   find_package(Aide 0.1 REQUIRED)
 endif()
 
-find_package(Qt6 COMPONENTS Core Widgets QUIET)
+find_package(Qt6 6.5 REQUIRED COMPONENTS Core Widgets)
 
-if(TARGET Qt6::Core)
-  find_package(Qt6LinguistTools)
-else()
-  find_package(Qt5 COMPONENTS Core Widgets REQUIRED)
-
-  if(NOT TARGET Qt::Core)
-    add_library(Qt::Core ALIAS Qt5::Core)
-    add_library(Qt::Widgets ALIAS Qt5::Widgets)
-  endif()
-
-  find_package(Qt5LinguistTools)
-  add_executable(Qt::lrelease ALIAS Qt5::lrelease)
-  add_executable(Qt::lupdate ALIAS Qt5::lupdate)
-endif()
+find_package(Qt6LinguistTools)
 
 add_subdirectory(src)

--- a/demo/src/CMakeLists.txt
+++ b/demo/src/CMakeLists.txt
@@ -5,27 +5,15 @@ set(CMAKE_AUTOMOC ON)
 
 if(TARGET Qt::lrelease)
   set_directory_properties(PROPERTIES CLEAN_NO_CUSTOM TRUE)
-  if(Qt6Core_VERSION_MAJOR)
-    qt_create_translation(
-      QM_FILES
-      ${CMAKE_CURRENT_SOURCE_DIR}
-      res/demo_de.ts
-      res/demo_en.ts
-      OPTIONS
-      -locations
-      none
-    )
-  else()
-    qt5_create_translation(
-      QM_FILES
-      ${CMAKE_CURRENT_SOURCE_DIR}
-      res/demo_de.ts
-      res/demo_en.ts
-      OPTIONS
-      -locations
-      none
-    )
-  endif()
+  qt_create_translation(
+    QM_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    res/demo_de.ts
+    res/demo_en.ts
+    OPTIONS
+    -locations
+    none
+  )
 
   configure_file(
     res/demo_translations.qrc.in
@@ -60,7 +48,7 @@ if(APPLE)
     TARGET aide_demo
     POST_BUILD
     COMMAND
-      ${CMAKE_INSTALL_NAME_TOOL} -add_rpath "${Qt5_DIR}/../../"
+      ${CMAKE_INSTALL_NAME_TOOL} -add_rpath "${Qt6_DIR}/../../"
       $<TARGET_FILE:aide_demo>
   )
 endif()

--- a/demo/src/demosettingspage.cpp
+++ b/demo/src/demosettingspage.cpp
@@ -182,9 +182,6 @@ DemoSettingsPage::DemoSettingsPage(
     , m_widget(nullptr)
 {
     qRegisterMetaType<WidgetState>("WidgetState");
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    qRegisterMetaTypeStreamOperators<WidgetState>("WidgetState");
-#endif
     m_tableInsertTimer->setInterval(1000);
 }
 

--- a/docs/core/appearance.md
+++ b/docs/core/appearance.md
@@ -74,11 +74,11 @@ Registered themes appear automatically in the Appearance settings page combo box
 
 ---
 
-## Following the OS color scheme (Qt 6.5+)
+## Following the OS color scheme
 
-When the active theme is **System** and you are building against **Qt 6.5 or newer**, `AppearanceManager` connects to `QStyleHints::colorSchemeChanged`. If the user switches their OS between light and dark mode while the app is running, the palette and icon theme are re-applied live and the appropriate signals are emitted.
+When the active theme is **System**, `AppearanceManager` connects to `QStyleHints::colorSchemeChanged`. If the user switches their OS between light and dark mode while the app is running, the palette and icon theme are re-applied live and the appropriate signals are emitted.
 
-The connection is wired up only while **System** is active; selecting a fixed theme disconnects it. On Qt 5 and Qt 6 versions below 6.5 the **System** theme still works but does not update until the next launch.
+The connection is wired up only while **System** is active; selecting a fixed theme disconnects it.
 
 ---
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -74,10 +74,10 @@ aIDE headers are namespaced under `aide/`. A minimal include set for a typical c
 |---|---|
 | CMake | 3.25 |
 | C++ compiler | C++20 — GCC 10+, Clang 12+, or MSVC 2019 16.11+ |
-| Qt | 5.15 LTS **or** 6.5+ |
+| Qt | 6.5+ |
 | Conan | 2.x *(if using the Conan integration)* |
 
-Qt 6 is preferred when available. aIDE builds and tests against both Qt 5.15 and Qt 6.5+ in CI.
+aIDE builds and tests against Qt 6.5+ in CI.
 
 ---
 

--- a/lsan.supp
+++ b/lsan.supp
@@ -1,5 +1,4 @@
 leak:libQt6*
-leak:libQt5*
 leak:libfontconfig*
 leak:libqoffscreen*
 leak:libwayland*

--- a/tests/dependencies/CMakeLists.txt
+++ b/tests/dependencies/CMakeLists.txt
@@ -1,21 +1,7 @@
 find_package(Catch2 REQUIRED)
 
-find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core)
+find_package(QT NAMES Qt6 REQUIRED COMPONENTS Core)
 
-find_package(Qt6 COMPONENTS Core Widgets Test QUIET)
+find_package(Qt6 6.5 REQUIRED COMPONENTS Core Widgets Test)
 
-if(TARGET Qt6::Test)
-  find_package(Qt6LinguistTools)
-else()
-  find_package(Qt5 COMPONENTS Widgets Test REQUIRED)
-
-  if(NOT TARGET Qt::Test)
-    add_library(Qt::Test ALIAS Qt5::Test)
-  elseif(NOT TARGET Qt::Widgets)
-    add_library(Qt::Widgets ALIAS Qt5::Widgets)
-  endif()
-
-  find_package(Qt5LinguistTools)
-  add_executable(Qt::lrelease ALIAS Qt5::lrelease)
-  add_executable(Qt::lupdate ALIAS Qt5::lupdate)
-endif()
+find_package(Qt6LinguistTools)

--- a/tests/ut/CMakeLists.txt
+++ b/tests/ut/CMakeLists.txt
@@ -10,16 +10,22 @@ add_library(aide_catch_main OBJECT catch_main.cpp sanitizerdefaults.cpp)
 target_link_libraries(
   aide_catch_main
   PUBLIC Catch2::Catch2
-  PRIVATE Aide::AideApplication Qt::Widgets aide_options aide_warnings
-          aide_coverage
+  PRIVATE
+    Aide::AideApplication
+    Qt::Widgets
+    aide_options
+    aide_warnings
+    aide_coverage
 )
 
 # Separate entry point for the [Application] tests: aide::Application is itself
 # a QApplication, so those tests must not run alongside the process-global
 # QApplication created in catch_main.cpp. This main deliberately creates none.
 add_library(
-  aide_catch_main_application OBJECT catch_main_application.cpp
-                                     sanitizerdefaults.cpp
+  aide_catch_main_application
+  OBJECT
+  catch_main_application.cpp
+  sanitizerdefaults.cpp
 )
 target_link_libraries(
   aide_catch_main_application
@@ -32,15 +38,9 @@ set(CMAKE_AUTORCC ON)
 if(TARGET Qt::lrelease)
   set_directory_properties(PROPERTIES CLEAN_NO_CUSTOM TRUE)
 
-  if(Qt6Core_VERSION_MAJOR)
-    qt_create_translation(
-      QM_FILES ${CMAKE_CURRENT_SOURCE_DIR} res/ut_sv.ts OPTIONS -locations none
-    )
-  else()
-    qt5_create_translation(
-      QM_FILES ${CMAKE_CURRENT_SOURCE_DIR} res/ut_sv.ts OPTIONS -locations none
-    )
-  endif()
+  qt_create_translation(
+    QM_FILES ${CMAKE_CURRENT_SOURCE_DIR} res/ut_sv.ts OPTIONS -locations none
+  )
 
   configure_file(
     res/ut_translations.qrc.in
@@ -152,7 +152,7 @@ if(APPLE)
     TARGET ut.aide
     POST_BUILD
     COMMAND
-      ${CMAKE_INSTALL_NAME_TOOL} -add_rpath "${Qt5_DIR}/../../"
+      ${CMAKE_INSTALL_NAME_TOOL} -add_rpath "${Qt6_DIR}/../../"
       $<TARGET_FILE:ut.aide>
   )
 endif()
@@ -211,7 +211,7 @@ if(APPLE)
     TARGET ut.aide.application
     POST_BUILD
     COMMAND
-      ${CMAKE_INSTALL_NAME_TOOL} -add_rpath "${Qt5_DIR}/../../"
+      ${CMAKE_INSTALL_NAME_TOOL} -add_rpath "${Qt6_DIR}/../../"
       $<TARGET_FILE:ut.aide.application>
   )
 endif()
@@ -264,12 +264,15 @@ aide_discover_unit_tests(ut.aide.application)
 # binaries run. Prevents a killed process from poisoning later runs with a
 # corrupt .gcda that crashes the gcov writeout at exit.
 if(aide_ENABLE_COVERAGE)
-  add_test(NAME reset_coverage_data
-           COMMAND ${CMAKE_COMMAND} -DGCDA_ROOT=${CMAKE_BINARY_DIR} -P
-                   ${CMAKE_CURRENT_LIST_DIR}/ResetCoverageData.cmake
+  add_test(
+    NAME reset_coverage_data
+    COMMAND
+      ${CMAKE_COMMAND} -DGCDA_ROOT=${CMAKE_BINARY_DIR} -P
+      ${CMAKE_CURRENT_LIST_DIR}/ResetCoverageData.cmake
   )
   set_tests_properties(
-    reset_coverage_data PROPERTIES FIXTURES_SETUP coverage_data
+    reset_coverage_data
+    PROPERTIES FIXTURES_SETUP coverage_data
   )
 endif()
 


### PR DESCRIPTION
## Summary

Closes #117

- Collapse every Qt5/Qt6 `find_package` + aliasing fallback (library, demo, tests) down to a direct, version-pinned `find_package(Qt6 6.5 ...)`; remove the `qt5_create_translation` branches, keeping only `qt_create_translation`; switch macOS rpath handling from `Qt5_DIR` to `Qt6_DIR`.
- Flatten the `QT_VERSION` preprocessor guards that only bridged Qt5 vs Qt6 or gated Qt6 minor versions at/below the new 6.5 floor, across the appearance manager, application translator, search line edit, tree/table views, search filter widget, search filter result delegate, multi-column sort/filter proxy model, change detector, and the demo settings page. The `>= 6.6.0` guard in the application translator is retained (genuine feature window above the new floor).
- Update README/CLAUDE.md/docs to state Qt6-only (minimum 6.5); remove the Qt5 job from the CI matrix.
- Add `ubuntu-26.04` to the `build_and_test` CI matrix for forward LTS coverage, alongside a `.github/actionlint.yaml` allowlist entry since the pinned actionlint doesn't yet recognize the (still public-preview) runner label.

Two commits, per the issue's implementation decisions: `feat!:` (breaking, Qt5 removal) and `ci:` (non-breaking, Ubuntu 26.04 addition).

## Test plan

- [x] `cmake --workflow --preset workflow-dev-unix-static-debug` on a clean build dir — 123/123 tests passed, 0 clang-tidy/cppcheck warnings
- [x] Two-axis `/code-review` (Standards + Spec) — 0 hard violations, 0 spec deviations

🤖 Generated with [Claude Code](https://claude.com/claude-code)